### PR TITLE
Remove dependency on Cucumber gem

### DIFF
--- a/lib/test_boosters/boosters/cucumber.rb
+++ b/lib/test_boosters/boosters/cucumber.rb
@@ -8,10 +8,6 @@ module TestBoosters
         super(FILE_PATTERN, nil, split_configuration_path, "bundle exec cucumber")
       end
 
-      def before_job
-        CucumberBoosterConfig::Injection.new(Dir.pwd, report_path).run
-      end
-
       def display_header
         super
 

--- a/spec/lib/test_boosters/boosters/cucumber_spec.rb
+++ b/spec/lib/test_boosters/boosters/cucumber_spec.rb
@@ -35,21 +35,6 @@ describe TestBoosters::Boosters::Cucumber do
     end
   end
 
-  describe "#before_job" do
-    before { ENV.delete("REPORT_PATH") }
-
-    it "injects cucumber flags" do
-      injector_double = double
-
-      expect(CucumberBoosterConfig::Injection).to receive(:new)
-        .with(Dir.pwd, "#{ENV["HOME"]}/cucumber_report.json").and_return(injector_double)
-
-      expect(injector_double).to receive(:run)
-
-      booster.before_job
-    end
-  end
-
   describe "#split_configuration_path" do
     before { ENV["CUCUMBER_SPLIT_CONFIGURATION_PATH"] = "/tmp/path.txt" }
 

--- a/test_boosters.gemspec
+++ b/test_boosters.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "semaphore_cucumber_booster_config", "~> 1.4.1"
   spec.add_runtime_dependency "ox", "~> 2.14"
 
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We don't use cucumber for anything, and this gem has a dependency on a very old version of Thor which causes compatibility issues when installing elsewhere.