### PR TITLE
Add quiet dry run

### DIFF
--- a/lib/test_boosters/boosters/base.rb
+++ b/lib/test_boosters/boosters/base.rb
@@ -11,13 +11,19 @@ module TestBoosters
 
       # :reek:TooManyStatements
       def run
-        display_header
+        display_header unless cli_options[:quiet_dry_run]
 
         before_job # execute some activities when the before the job starts
 
-        distribution.display_info
+        distribution.display_info unless cli_options[:quiet_dry_run]
 
         known, leftover = distribution.files_for(job_index)
+
+        if cli_options[:quiet_dry_run]
+          files = known + leftover
+          puts files.join(" ")
+          return 0
+        end
 
         if cli_options[:dry_run]
           show_files_for_dry_run("known", known)

--- a/lib/test_boosters/cli_parser.rb
+++ b/lib/test_boosters/cli_parser.rb
@@ -31,6 +31,13 @@ module TestBoosters
         ) do |parameter|
           options.merge!(:dry_run => parameter)
         end
+
+        opts.on(
+          "--quiet-dry-run",
+          "Only print the files that will be run for this job index with no extra information"
+        ) do |parameter|
+          options.merge!(:quiet_dry_run => parameter)
+        end
       end
 
       parser.parse!


### PR DESCRIPTION
We need just a list of the files for some Airflow-specific timing improvements.

Ideally we'd split the various `puts` statements into actual log streams and be able to set log level, but that would be a bigger refactor.