### PR TITLE
Filter out null specs ending up in split_configuration

### DIFF
--- a/lib/test_boosters/files/split_configuration.rb
+++ b/lib/test_boosters/files/split_configuration.rb
@@ -40,7 +40,7 @@ module TestBoosters
         @valid = false
 
         content = JSON.parse(File.read(@path)).map do |raw_job|
-          files = raw_job.fetch("files").sort
+          files = raw_job.fetch("files").compact.sort
 
           TestBoosters::Files::SplitConfiguration::Job.new(files)
         end

--- a/lib/test_boosters/version.rb
+++ b/lib/test_boosters/version.rb
@@ -1,3 +1,3 @@
 module TestBoosters
-  VERSION = "2.7.0".freeze
+  VERSION = "2.7.0.1".freeze
 end

--- a/lib/test_collectors/collectors/base.rb
+++ b/lib/test_collectors/collectors/base.rb
@@ -83,7 +83,7 @@ module TestCollectors
               end
             end
 
-            timing_bin[:specs] << spec_file
+            timing_bin[:specs] << spec_file unless spec_file.nil?
             timing_bin[:runtime] += spec_timing
           end
 


### PR DESCRIPTION
This is awkward because we're not exactly sure how a null value is ending up in a list of files in split_configuration.json. We're updating the code to handle it better than it currently does - blows up.
We're still investigating a possible root cause.

Gem version updated from 2.7.0 to 2.7.0.1